### PR TITLE
RC (MissileCamera: Remote Control) page

### DIFF
--- a/src/plugin/CommandDispatcher.cs
+++ b/src/plugin/CommandDispatcher.cs
@@ -42,6 +42,12 @@ namespace NOXMFD
         public float  wx;      // wpt.add-waypoint : world X (floating-origin corrected)
         public float  wz;      // wpt.add-waypoint : world Z
         public string text;    // wpt.import : the pasted route-export JSON blob
+
+        // RC (MissileCamera: Remote Control) continuous values — the only other float fields in
+        // the envelope besides hz, so far only RC needs anything analog beyond that.
+        public float  x;       // rc.aim : yaw delta, degrees (right positive) — one frame's pointer/drag delta
+        public float  y;       // rc.aim : pitch delta, degrees (up negative) — same sign convention as RcBridge
+        public float  v;       // rc.throttle-set : absolute 0..1 · rc.throttle-adjust : relative delta
     }
 
     internal static class CommandDispatcher
@@ -120,6 +126,22 @@ namespace NOXMFD
                 { "wpt.cycle-route",      e => RouteStore.CycleActiveRoute(e.index) },
                 { "wpt.step-waypoint",    e => RouteStore.StepWaypoint(e.index) },
                 { "wpt.add-waypoint",     e => RouteStore.AddWaypoint(e.wx, e.wz, e.wname) },
+                // MissileCamera: Remote Control (soft dependency — RcBridge.cs). Every handler is a
+                // direct forward onto RcBridge/McBridge, which themselves no-op when the relevant mod
+                // isn't installed or not currently controlling — so these are safe to wire up
+                // unconditionally, the same as any other command, rather than gating registration on
+                // an Available check.
+                { "rc.aim",             e => RcBridge.InjectAimDelta(e.x, e.y) },
+                { "rc.throttle-set",    e => RcBridge.SetThrottle01(e.v) },
+                { "rc.throttle-adjust", e => RcBridge.AdjustThrottle(e.v) },
+                { "rc.boost",           e => RcBridge.SetBoostHeld(e.on) },
+                { "rc.take",            e => RcBridge.TakeNearest() },
+                { "rc.take-at",         e => RcBridge.TakeAt(e.index) },
+                { "rc.release",         e => RcBridge.Release() },
+                { "rc.formation",       e => RcBridge.ToggleFormationFollow() },
+                { "rc.detonate",        e => RcBridge.ManualDetonate() },
+                { "rc.refresh-pool",    e => RcBridge.RefreshPool() },
+                { "rc.vision-cycle",    e => McBridge.CycleVisionMode() },
             };
 
         // Keybind writes just delegate to the Keybinds registry; log rejections (unknown id / bad key).

--- a/src/plugin/McBridge.cs
+++ b/src/plugin/McBridge.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Reflection;
+using UnityEngine;
+
+namespace NOXMFD
+{
+    // Soft dependency on the BASE "Missile Camera" mod's public Bridge (Bridge/McBridge.cs there) —
+    // separate from RcBridge.cs, which talks to MissileCameraRemoteControl (the RC add-on). This one
+    // is what makes the /rc feed work WITHOUT the pilot entering fullscreen or having the cockpit MFD
+    // panel bound: McBridge.RequestCapture(true) adds NOXMFD as a third legitimate reason for the
+    // base mod's feed pipeline to stay live, alongside the cockpit panel and Fullscreen — see that
+    // mod's MissileCameraFeedController.IsDisplayPipelineActive / CAMERA_SAFETY.md.
+    //
+    // Same resolution shape as RcBridge.cs: cached delegates via reflection, retried on a cooldown
+    // since plugin load order between mods isn't guaranteed, every member safe/no-op until resolved.
+    internal static class McBridge
+    {
+        private const int MinApiVersion = 1;
+
+        private static bool  _resolved;
+        private static float _nextAttempt;
+
+        private static Func<bool>?    _hasTrackableMissile;
+        private static Func<Camera>?  _feedCamera;
+        private static Func<Texture>? _feedTexture;
+        private static Func<string>?  _telemetryJson;
+        private static Func<string>?  _markersJson;
+        private static Action?        _cycleVisionMode;
+        private static Action<bool>?  _requestCapture;
+
+        internal static bool Available => EnsureResolved();
+
+        internal static bool    HasTrackableMissile => Available && _hasTrackableMissile!();
+        internal static Camera? FeedCamera           => Available ? _feedCamera!() : null;
+
+        // Prefer this over FeedCamera.targetTexture — see McBridge.cs (base mod) for why: the
+        // camera's own targetTexture is swapped to an intermediate HDR buffer mid-render and
+        // restored afterward, so it doesn't reliably hold the final picture at an arbitrary read
+        // time the way this authoritative output texture does.
+        internal static Texture? FeedTexture         => Available ? _feedTexture!() : null;
+
+        // Raw JSON straight from the base mod (McBridge.TelemetryJson) — spliced verbatim into our
+        // own "rc" telemetry block rather than parsed, since it's already valid, pre-escaped JSON
+        // with exactly the fields/formatting we want (see McBridge.cs there for the field list).
+        internal static string? TelemetryJson => Available ? _telemetryJson!() : null;
+
+        // Raw JSON array straight from the base mod (McBridge.MarkersJson) — spliced verbatim
+        // into the "rc" block's "markers" key, same reasoning as TelemetryJson above. "[]" (not
+        // null) when unavailable, since rc.js always expects an array here.
+        internal static string MarkersJson => Available ? (_markersJson!() ?? "[]") : "[]";
+
+        // Cycle the Fullscreen-style vision filter (Color/NightVision/WhiteHot/BlackHot/Contour) —
+        // current mode's label rides inside TelemetryJson's "visionMode" field, not a separate call.
+        internal static void CycleVisionMode() { if (Available) _cycleVisionMode!(); }
+
+        // Level-triggered — call every tick with the current "do I still need frames" state (false
+        // once WantsRcFrames drops, same as RcFeed already does for its own gating). No-op when the
+        // base mod's Bridge isn't present, so callers don't need to guard this themselves.
+        internal static void RequestCapture(bool active) { if (Available) _requestCapture!(active); }
+
+        private static bool EnsureResolved()
+        {
+            if (_resolved) return true;
+            if (Time.unscaledTime < _nextAttempt) return false;
+            _nextAttempt = Time.unscaledTime + 2f;
+
+            try
+            {
+                Assembly? asm = null;
+                foreach (Assembly a in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    if (a.GetName().Name == "MissileCamera") { asm = a; break; }
+                }
+                if (asm == null) return false;   // base mod not installed — normal, not an error
+
+                Type? t = asm.GetType("MissileCamera.Bridge.McBridge");
+                if (t == null)
+                {
+                    Plugin.Log?.LogWarning("[NOXMFD] MissileCamera found but has no Bridge — too old? Headless RC capture disabled (falls back to fullscreen-gated feed).");
+                    return false;
+                }
+
+                FieldInfo? verField = t.GetField("ApiVersion", BindingFlags.Public | BindingFlags.Static);
+                int ver = verField != null ? (int)verField.GetValue(null) : 0;
+                if (ver < MinApiVersion)
+                {
+                    Plugin.Log?.LogWarning($"[NOXMFD] MissileCamera Bridge ApiVersion {ver} < {MinApiVersion} — headless RC capture disabled.");
+                    return false;
+                }
+
+                _hasTrackableMissile = BindGet<bool>(t, "HasTrackableMissile");
+                _feedCamera          = BindGet<Camera>(t, "FeedCamera");
+                _feedTexture         = BindGet<Texture>(t, "FeedTexture");
+                _telemetryJson       = BindFunc<string>(t, "TelemetryJson");
+                _markersJson         = BindFunc<string>(t, "MarkersJson");
+                _cycleVisionMode     = BindAction(t, "CycleVisionMode");
+                _requestCapture      = BindAction1<bool>(t, "RequestCapture");
+
+                _resolved = _hasTrackableMissile != null && _feedCamera != null
+                    && _feedTexture != null && _telemetryJson != null && _markersJson != null
+                    && _cycleVisionMode != null
+                    && _requestCapture != null;
+                if (_resolved)
+                    Plugin.Log?.LogInfo("[NOXMFD] MissileCamera Bridge found (v" + ver + ") — headless RC capture enabled.");
+                else
+                    Plugin.Log?.LogWarning("[NOXMFD] MissileCamera Bridge shape mismatch — headless RC capture disabled.");
+                return _resolved;
+            }
+            catch (Exception ex)
+            {
+                Plugin.Log?.LogWarning($"[NOXMFD] MissileCamera bridge resolve failed: {ex.Message}");
+                return false;
+            }
+        }
+
+        private static Func<TRet>? BindGet<TRet>(Type t, string propName)
+        {
+            MethodInfo? get = t.GetProperty(propName, BindingFlags.Public | BindingFlags.Static)?.GetGetMethod();
+            return get == null ? null : (Func<TRet>)Delegate.CreateDelegate(typeof(Func<TRet>), get);
+        }
+
+        private static Func<TRet>? BindFunc<TRet>(Type t, string methodName)
+        {
+            MethodInfo? m = t.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static, null, Type.EmptyTypes, null);
+            return m == null ? null : (Func<TRet>)Delegate.CreateDelegate(typeof(Func<TRet>), m);
+        }
+
+        private static Action<T1>? BindAction1<T1>(Type t, string methodName)
+        {
+            MethodInfo? m = t.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static, null, new[] { typeof(T1) }, null);
+            return m == null ? null : (Action<T1>)Delegate.CreateDelegate(typeof(Action<T1>), m);
+        }
+
+        private static Action? BindAction(Type t, string methodName)
+        {
+            MethodInfo? m = t.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static, null, Type.EmptyTypes, null);
+            return m == null ? null : (Action)Delegate.CreateDelegate(typeof(Action), m);
+        }
+    }
+}

--- a/src/plugin/RcBridge.cs
+++ b/src/plugin/RcBridge.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace NOXMFD
+{
+    // Soft dependency on MissileCameraRemoteControl's public Bridge (Bridge/McRcBridge.cs there),
+    // if that mod is installed. Located purely via reflection at runtime — NOXMFD does not
+    // reference RC's assembly, compiles and runs identically whether or not RC is present, exactly
+    // like MissileCameraFsAccess does on the RC side for MissileCamera itself.
+    //
+    // Resolved once into cached delegates (Delegate.CreateDelegate — a direct call afterward, not
+    // a per-invocation Invoke), retried on a cooldown since BepInEx plugin load order between two
+    // separate mods isn't guaranteed. Every member below no-ops / returns a safe default until
+    // resolved, so callers (RcFeed, TelemetryReader, CommandDispatcher) never need to check
+    // Available themselves first.
+    internal static class RcBridge
+    {
+        // Bump if McRcBridge's ApiVersion moves past what this file's Bind* calls assume.
+        private const int MinApiVersion = 1;
+
+        private static bool  _resolved;
+        private static float _nextAttempt;
+
+        private static Func<bool>?    _isFullscreenActive;
+        private static Func<bool>?    _isControlling;
+        private static Func<Camera>?  _feedCamera;
+        private static Func<string>?  _controlledMissileName;
+        private static Func<float>?   _throttle01;
+        private static Func<bool>?    _boostActive;
+        private static Func<string>?  _linkQuality;
+        private static Func<Vector2>? _reticleViewport;
+        private static Func<bool>?    _formationFollowActive;
+        private static Func<IReadOnlyList<string>>? _controllablePool;
+
+        private static Action?             _refreshPool;
+        private static Func<bool>?         _takeNearest;
+        private static Func<int, bool>?    _takeAt;
+        private static Action?             _release;
+        private static Action<float, float>? _injectAimDelta;
+        private static Action<float>?      _setThrottle01;
+        private static Action<float>?      _adjustThrottle;
+        private static Action<bool>?       _setBoostHeld;
+        private static Action?             _toggleFormationFollow;
+        private static Func<bool>?         _manualDetonate;
+
+        internal static bool Available => EnsureResolved();
+
+        // ── State ──────────────────────────────────────────────────────────────
+        internal static bool    IsFullscreenActive     => Available && _isFullscreenActive!();
+        internal static bool    IsControlling           => Available && _isControlling!();
+        internal static Camera? FeedCamera               => Available ? _feedCamera!() : null;
+        internal static string  ControlledMissileName    => Available ? _controlledMissileName!() : string.Empty;
+        internal static float   Throttle01                => Available ? _throttle01!() : 0f;
+        internal static bool    BoostActive               => Available && _boostActive!();
+        internal static string  LinkQuality                => Available ? _linkQuality!() : string.Empty;
+        internal static Vector2 ReticleViewport             => Available ? _reticleViewport!() : new Vector2(0.5f, 0.5f);
+        internal static bool    FormationFollowActive        => Available && _formationFollowActive!();
+        internal static IReadOnlyList<string> ControllablePool =>
+            Available ? _controllablePool!() : Array.Empty<string>();
+
+        // ── Commands (all safe no-ops when unavailable) ──────────────────────────
+        internal static void RefreshPool()                        { if (Available) _refreshPool!(); }
+        internal static bool TakeNearest()                        => Available && _takeNearest!();
+        internal static bool TakeAt(int index)                    => Available && _takeAt!(index);
+        internal static void Release()                            { if (Available) _release!(); }
+        internal static void InjectAimDelta(float yawDeg, float pitchDeg)
+                                                                    { if (Available) _injectAimDelta!(yawDeg, pitchDeg); }
+        internal static void SetThrottle01(float value01)         { if (Available) _setThrottle01!(value01); }
+        internal static void AdjustThrottle(float delta)          { if (Available) _adjustThrottle!(delta); }
+        internal static void SetBoostHeld(bool held)              { if (Available) _setBoostHeld!(held); }
+        internal static void ToggleFormationFollow()              { if (Available) _toggleFormationFollow!(); }
+        internal static bool ManualDetonate()                     => Available && _manualDetonate!();
+
+        private static bool EnsureResolved()
+        {
+            if (_resolved) return true;
+            if (Time.unscaledTime < _nextAttempt) return false;
+            _nextAttempt = Time.unscaledTime + 2f;   // RC may load after us — keep retrying, cheaply
+
+            try
+            {
+                Assembly? asm = null;
+                foreach (Assembly a in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    if (a.GetName().Name == "MissileCameraRemoteControl") { asm = a; break; }
+                }
+                if (asm == null) return false;   // RC not installed — normal, not an error
+
+                Type? t = asm.GetType("MissileCameraRemoteControl.Bridge.McRcBridge");
+                if (t == null)
+                {
+                    Plugin.Log?.LogWarning("[NOXMFD] MissileCameraRemoteControl found but has no Bridge — too old? RC page disabled.");
+                    return false;
+                }
+
+                FieldInfo? verField = t.GetField("ApiVersion", BindingFlags.Public | BindingFlags.Static);
+                int ver = verField != null ? (int)verField.GetValue(null) : 0;
+                if (ver < MinApiVersion)
+                {
+                    Plugin.Log?.LogWarning($"[NOXMFD] MissileCameraRemoteControl Bridge ApiVersion {ver} < {MinApiVersion} — RC page disabled.");
+                    return false;
+                }
+
+                _isFullscreenActive    = BindGet<bool>(t, "IsFullscreenActive");
+                _isControlling         = BindGet<bool>(t, "IsControlling");
+                _feedCamera            = BindGet<Camera>(t, "FeedCamera");
+                _controlledMissileName = BindGet<string>(t, "ControlledMissileName");
+                _throttle01            = BindGet<float>(t, "Throttle01");
+                _boostActive           = BindGet<bool>(t, "BoostActive");
+                _linkQuality           = BindGet<string>(t, "LinkQuality");
+                _reticleViewport       = BindGet<Vector2>(t, "ReticleViewport");
+                _formationFollowActive = BindGet<bool>(t, "FormationFollowActive");
+                _controllablePool      = BindGet<IReadOnlyList<string>>(t, "ControllablePool");
+
+                _refreshPool           = BindAction(t, "RefreshPool");
+                _takeNearest           = BindFunc<bool>(t, "TakeNearest");
+                _takeAt                = BindFuncArg<int, bool>(t, "TakeAt");
+                _release               = BindAction(t, "Release");
+                _injectAimDelta        = BindAction2<float, float>(t, "InjectAimDelta");
+                _setThrottle01         = BindAction1<float>(t, "SetThrottle01");
+                _adjustThrottle        = BindAction1<float>(t, "AdjustThrottle");
+                _setBoostHeld          = BindAction1<bool>(t, "SetBoostHeld");
+                _toggleFormationFollow = BindAction(t, "ToggleFormationFollow");
+                _manualDetonate        = BindFunc<bool>(t, "ManualDetonate");
+
+                // Sanity: bail (retry later) if reflection didn't find everything we need — a half
+                // -bound bridge is worse than none, since Available would gate real calls but a
+                // null delegate would still throw NullReferenceException at the call site.
+                _resolved = _isFullscreenActive != null && _isControlling != null && _feedCamera != null
+                    && _controlledMissileName != null && _throttle01 != null && _boostActive != null
+                    && _linkQuality != null && _reticleViewport != null && _formationFollowActive != null
+                    && _controllablePool != null && _refreshPool != null && _takeNearest != null
+                    && _takeAt != null && _release != null && _injectAimDelta != null
+                    && _setThrottle01 != null && _adjustThrottle != null && _setBoostHeld != null
+                    && _toggleFormationFollow != null && _manualDetonate != null;
+
+                if (_resolved)
+                    Plugin.Log?.LogInfo("[NOXMFD] MissileCameraRemoteControl Bridge found (v" + ver + ") — RC page enabled.");
+                else
+                    Plugin.Log?.LogWarning("[NOXMFD] MissileCameraRemoteControl Bridge shape mismatch — RC page disabled.");
+                return _resolved;
+            }
+            catch (Exception ex)
+            {
+                Plugin.Log?.LogWarning($"[NOXMFD] RC bridge resolve failed: {ex.Message}");
+                return false;
+            }
+        }
+
+        // ── Delegate binding helpers ──────────────────────────────────────────────
+        private static Func<TRet>? BindGet<TRet>(Type t, string propName)
+        {
+            MethodInfo? get = t.GetProperty(propName, BindingFlags.Public | BindingFlags.Static)?.GetGetMethod();
+            return get == null ? null : (Func<TRet>)Delegate.CreateDelegate(typeof(Func<TRet>), get);
+        }
+
+        private static Action? BindAction(Type t, string methodName)
+        {
+            MethodInfo? m = t.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static, null, Type.EmptyTypes, null);
+            return m == null ? null : (Action)Delegate.CreateDelegate(typeof(Action), m);
+        }
+
+        private static Action<T1>? BindAction1<T1>(Type t, string methodName)
+        {
+            MethodInfo? m = t.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static, null, new[] { typeof(T1) }, null);
+            return m == null ? null : (Action<T1>)Delegate.CreateDelegate(typeof(Action<T1>), m);
+        }
+
+        private static Action<T1, T2>? BindAction2<T1, T2>(Type t, string methodName)
+        {
+            MethodInfo? m = t.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static, null, new[] { typeof(T1), typeof(T2) }, null);
+            return m == null ? null : (Action<T1, T2>)Delegate.CreateDelegate(typeof(Action<T1, T2>), m);
+        }
+
+        private static Func<TRet>? BindFunc<TRet>(Type t, string methodName)
+        {
+            MethodInfo? m = t.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static, null, Type.EmptyTypes, null);
+            return m == null ? null : (Func<TRet>)Delegate.CreateDelegate(typeof(Func<TRet>), m);
+        }
+
+        private static Func<T1, TRet>? BindFuncArg<T1, TRet>(Type t, string methodName)
+        {
+            MethodInfo? m = t.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static, null, new[] { typeof(T1) }, null);
+            return m == null ? null : (Func<T1, TRet>)Delegate.CreateDelegate(typeof(Func<T1, TRet>), m);
+        }
+    }
+}

--- a/src/plugin/RcFeed.cs
+++ b/src/plugin/RcFeed.cs
@@ -1,0 +1,208 @@
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace NOXMFD
+{
+    // The MissileCamera: Remote Control feed — same continuous-capture pipeline as TgpFeed.cs, but
+    // sourced from RcBridge.FeedCamera (a soft dependency on another mod) instead of the game's
+    // own TargetCam. Gated the same way: zero cost while nobody has the /rc page open, via
+    // TelemetryServer.WantsRcFrames — see docs/rc-page.md for the full protocol this feeds.
+    //
+    // A plain object (not a MonoBehaviour), owned by TelemetryReader exactly like _tgp: driven via
+    // Tick(dt) each frame, Active mirrored into the snapshot, torn down from OnDestroy.
+    internal class RcFeed
+    {
+        // 20 Hz: this is the pilot's direct aiming view (vs. TGP's 15 Hz targeting reference), so
+        // it gets a bit more headroom for smooth tracking of a fast-moving reticle.
+        internal const float Interval    = 1f / 20f;
+        private  const int   MaxDim      = 720;
+        private  const int   JpegQuality = 55;
+
+        private float          _timer;
+        private RenderTexture? _rt;
+        private Texture2D?     _tex;
+        private bool           _engaged;
+        private bool           _active;
+        private bool           _srcLogged;
+        private bool           _pixelDiagLogged;
+        private bool           _hadSrc;
+        private bool           _readbackInFlight;
+
+        public bool Active => _active;
+
+        public void Tick(float dt)
+        {
+            _timer += dt;
+            if (_timer < Interval) return;
+            _timer = 0f;
+            CaptureFrame();
+        }
+
+        private void CaptureFrame()
+        {
+            // Gate on /rc.mjpg subscribers — same reasoning as TgpFeed: no point reading RcBridge
+            // or touching a Camera every tick when no client has the RC page open. This gate is
+            // also what drives McBridge.RequestCapture below — see that call for why it must run
+            // even on the "no subscribers" branch, not just here.
+            if (!TelemetryServer.WantsRcFrames)
+            {
+                McBridge.RequestCapture(false);
+                if (_engaged) Disengage();
+                return;
+            }
+
+            // Ask the BASE "Missile Camera" mod to keep its feed pipeline live for us — this is
+            // what removes the need for the pilot to enter fullscreen or have the cockpit MFD panel
+            // bound (docs/rc-page.md). Level-triggered, so this runs every tick we still want
+            // frames; safe no-op if that mod isn't installed or is a version without Bridge.
+            McBridge.RequestCapture(true);
+
+            // Prefer the base mod's own Bridge texture (works headless, per above — and is the
+            // actual authoritative output, not read off the camera mid-render — see McBridge.cs).
+            // Fall back to RcBridge's fullscreen-gated camera.targetTexture for older MissileCamera
+            // installs without a Bridge — same picture, just requires the pilot to actually be in
+            // fullscreen for it to be non-null/valid.
+            Texture? src;
+            bool haveCam;   // only meaningful on the fallback path — see the enabled check below
+            if (McBridge.Available)
+            {
+                src = McBridge.FeedTexture;
+                haveCam = true;
+            }
+            else
+            {
+                Camera? cam = RcBridge.FeedCamera;
+                haveCam = cam != null && cam.enabled;
+                src = haveCam ? cam!.targetTexture : null;
+            }
+            if (!haveCam || src == null)
+            {
+                TelemetryServer.ClearRcFrame();
+                _active = false;
+                if (_hadSrc)
+                {
+                    // Transition log (not a one-shot like _srcLogged below) — if capture silently
+                    // stops mid-session, this is what tells us when/why on the next log, instead of
+                    // total silence after the one-time startup dump.
+                    _hadSrc = false;
+                    Plugin.Log?.LogWarning("[NOXMFD] RC: feed became unavailable "
+                        + $"(McBridge.Available={McBridge.Available}, HasTrackableMissile={McBridge.HasTrackableMissile}, "
+                        + $"haveCam={haveCam}).");
+                }
+                return;
+            }
+            if (!_hadSrc)
+            {
+                _hadSrc = true;
+                Plugin.Log?.LogInfo("[NOXMFD] RC: feed (re)available.");
+            }
+
+            // Match the captured frame to the source's aspect ratio — see TgpFeed for why (avoids
+            // squashing a wider-than-tall feed; the MFD page letterboxes with object-fit:contain).
+            int sw = Mathf.Max(1, src.width);
+            int sh = Mathf.Max(1, src.height);
+            int targetW, targetH;
+            int maxSide = Mathf.Max(sw, sh);
+            if (maxSide <= MaxDim)
+            {
+                targetW = sw; targetH = sh;
+            }
+            else if (sw >= sh)
+            {
+                targetW = MaxDim;
+                targetH = Mathf.Max(1, Mathf.RoundToInt(MaxDim * (float)sh / sw));
+            }
+            else
+            {
+                targetH = MaxDim;
+                targetW = Mathf.Max(1, Mathf.RoundToInt(MaxDim * (float)sw / sh));
+            }
+
+            if (!_srcLogged)
+            {
+                _srcLogged = true;
+                Plugin.Log?.LogInfo($"[NOXMFD] RC source texture {sw}x{sh} (aspect {(float)sw / sh:0.000}); capturing at {targetW}x{targetH}.");
+
+                // Diagnostic: camera state itself, when we have one to inspect (McBridge only
+                // exposes the texture, so fetch its Camera separately just for this one-time log —
+                // harmless extra reflection call, not on the hot path since _srcLogged guards it).
+                Camera? diagCam = McBridge.Available ? McBridge.FeedCamera : null;
+                if (diagCam != null)
+                {
+                    Plugin.Log?.LogInfo($"[NOXMFD] RC feed camera diag: enabled={diagCam.enabled}, "
+                        + $"cullingMask={diagCam.cullingMask}, clip=[{diagCam.nearClipPlane:0.###},{diagCam.farClipPlane:0.#}], "
+                        + $"fov={diagCam.fieldOfView:0.#}, targetTexture={(diagCam.targetTexture != null ? diagCam.targetTexture.GetInstanceID().ToString() : "null")}, "
+                        + $"feedTexture={src.GetInstanceID()}, sameRT={(diagCam.targetTexture == src)}.");
+                }
+            }
+
+            // Don't stack readbacks — drop this tick if the GPU is still finishing the last one.
+            if (_readbackInFlight) return;
+
+            if (_rt == null || _rt.width != targetW || _rt.height != targetH)
+            {
+                if (_rt != null) { _rt.Release(); Object.Destroy(_rt); }
+                _rt = new RenderTexture(targetW, targetH, 0, RenderTextureFormat.ARGB32);
+                _rt.Create();
+            }
+            if (_tex == null || _tex.width != targetW || _tex.height != targetH)
+            {
+                if (_tex != null) Object.Destroy(_tex);
+                _tex = new Texture2D(targetW, targetH, TextureFormat.RGBA32, false);
+            }
+
+            Graphics.Blit(src, _rt);
+            _readbackInFlight = true;
+            int captureW = targetW;
+            int captureH = targetH;
+            AsyncGPUReadback.Request(_rt, 0, request => OnReadbackComplete(request, captureW, captureH));
+        }
+
+        private void OnReadbackComplete(AsyncGPUReadbackRequest request, int w, int h)
+        {
+            _readbackInFlight = false;
+            if (request.hasError) return;
+            if (!TelemetryServer.WantsRcFrames) return;                 // disengaged while in flight
+            if (_tex == null || _tex.width != w || _tex.height != h) return;
+
+            var data = request.GetData<byte>();
+
+            // One-time diagnostic: is the captured buffer actually black, or does it have real
+            // content that's getting lost downstream (JPEG encode / MJPEG serving / browser)?
+            // Sampled every 97th byte (prime, avoids landing on the same channel every time) so
+            // this stays cheap even though it only ever runs once per RcFeed instance.
+            if (!_pixelDiagLogged)
+            {
+                _pixelDiagLogged = true;
+                long sum = 0; int n = 0;
+                for (int i = 0; i < data.Length; i += 97) { sum += data[i]; n++; }
+                double avg = n > 0 ? (double)sum / n : -1;
+                Plugin.Log?.LogInfo($"[NOXMFD] RC frame diag: {w}x{h}, avg sampled byte ≈ {avg:0.0} (0=black, 255=white/full).");
+            }
+
+            _tex.LoadRawTextureData(data);
+            _tex.Apply(false, false);
+
+            byte[] jpg = _tex.EncodeToJPG(JpegQuality);
+            TelemetryServer.PushRcFrame(jpg);
+            _active  = true;
+            _engaged = true;
+        }
+
+        public void Disengage()
+        {
+            McBridge.RequestCapture(false);   // e.g. OnDestroy calling this directly, not via CaptureFrame
+            if (_rt  != null) { _rt.Release();  Object.Destroy(_rt);  _rt  = null; }
+            if (_tex != null) {                 Object.Destroy(_tex); _tex = null; }
+
+            bool wasEngaged   = _engaged;
+            _engaged          = false;
+            _active           = false;
+            _srcLogged        = false;
+            _hadSrc           = false;
+            _readbackInFlight = false;
+            TelemetryServer.ClearRcFrame();
+            if (wasEngaged) Plugin.Log?.LogInfo("[NOXMFD] RC: disengaged (no subscribers).");
+        }
+    }
+}

--- a/src/plugin/TelemetryReader.cs
+++ b/src/plugin/TelemetryReader.cs
@@ -113,6 +113,11 @@ namespace NOXMFD
         // mirrored into the snapshot, and torn down from OnDestroy. See TgpFeed.cs.
         private readonly TgpFeed _tgp = new TgpFeed();
 
+        // RC (MissileCamera: Remote Control) feed — same shape as TgpFeed, but sourced from a soft
+        // dependency on another pair of mods (RcBridge.cs / McBridge.cs) instead of the game's own
+        // TargetCam. See RcFeed.cs.
+        private readonly RcFeed _rc = new RcFeed();
+
         // ── RWR (radar warning) ───────────────────────────────────────────────────
         // The game raises Aircraft.onRadarWarning once per radar sweep that paints the player
         // (a Mirage ClientRpc, so on the main thread — same as our Update). It's a transient
@@ -192,6 +197,7 @@ namespace NOXMFD
             }
 
             _tgp.Tick(dt);   // TGP feed cadence is owned by TgpFeed (captures at its own interval)
+            _rc.Tick(dt);    // RC feed cadence is owned by RcFeed (captures at its own interval)
         }
 
         private void ScanWorld()
@@ -288,6 +294,13 @@ namespace NOXMFD
         private static AkfKillEntry[] ToArray(IReadOnlyList<AkfKillEntry> list)
         {
             var arr = new AkfKillEntry[list.Count];
+            for (int i = 0; i < list.Count; i++) arr[i] = list[i];
+            return arr;
+        }
+
+        private static string[] ToStringArray(IReadOnlyList<string> list)
+        {
+            var arr = new string[list.Count];
             for (int i = 0; i < list.Count; i++) arr[i] = list[i];
             return arr;
         }
@@ -842,6 +855,22 @@ namespace NOXMFD
                 ColHostile     = _colHostile,
                 ColNeutral     = _colNeutral,
                 TgpActive      = _tgp.Active,
+                RcAvailable    = RcBridge.Available,
+                // ponytail: RcFsActive drives rc.js's "CAMERA NOT ACTIVE" empty state — using
+                // _rc.Active (frames actually flowing) rather than RcBridge.IsFullscreenActive,
+                // since with McBridge wired we force-capture without fullscreen (RcFeed.cs), so
+                // fullscreen state alone would misreport. Ceiling: lags one capture interval
+                // (~50ms) behind the true pipeline state — not noticeable at this refresh rate.
+                RcFsActive     = _rc.Active,
+                RcControlling  = RcBridge.IsControlling,
+                RcMissileName  = RcBridge.ControlledMissileName,
+                RcThrottle     = RcBridge.Throttle01,
+                RcBoost        = RcBridge.BoostActive,
+                RcLink         = RcBridge.LinkQuality,
+                RcFormation    = RcBridge.FormationFollowActive,
+                RcPool         = ToStringArray(RcBridge.ControllablePool),
+                RcTeleJson     = McBridge.TelemetryJson,
+                RcMarkersJson  = McBridge.MarkersJson,
                 Parts          = BuildParts(aircraft),
                 Failures       = BuildFailures(),
                 Rwr            = BuildRwr(aircraft),
@@ -1363,6 +1392,7 @@ namespace NOXMFD
         private void OnDestroy()
         {
             _tgp.Disengage();
+            _rc.Disengage();
             if (_rwrSubscribed != null) { _rwrSubscribed.onRadarWarning -= OnRadarWarning; _rwrSubscribed = null; }
             if (AkfTracker.Active == _akf) AkfTracker.Active = null;
         }

--- a/src/plugin/TelemetryServer.cs
+++ b/src/plugin/TelemetryServer.cs
@@ -116,6 +116,19 @@ namespace NOXMFD
         private static int _tgpSubscribers;
         public static bool WantsTgpFrames => Volatile.Read(ref _tgpSubscribers) > 0;
 
+        // Latest RC (MissileCamera: Remote Control) feed frame — same shape as the TGP block
+        // above, served at /rc.mjpg. See RcFeed.cs / RcBridge.cs / McBridge.cs.
+        private static byte[]? _rcJpg;
+        private static long    _rcFrameId;
+        private static readonly object _rcLock = new object();
+        private static int _rcSubscribers;
+        public static bool WantsRcFrames => Volatile.Read(ref _rcSubscribers) > 0;
+
+        // RC aim reticle viewport position — its own high-rate channel (SSE event "rcaim"), same
+        // reasoning and shape as the MAP cursor (_cursorX/_cursorY below): a continuous analog
+        // value that would feel laggy riding the 10 Hz telemetry frame.
+        private static float _rcAimX = 0.5f, _rcAimY = 0.5f;
+
         // ── Connected MFD instances (SOI — docs/keybinds-page.md) ──────────────
         // One /stream connection IS one MFD instance: HandleSseAsync runs for exactly as long as a
         // browser sits on the display, so registering on entry and dropping in its existing finally
@@ -609,6 +622,35 @@ namespace NOXMFD
             lock (_tgpLock) { _tgpJpg = null; _tgpFrameId++; }
         }
 
+        // Called from Unity main thread with each captured RC (remote-control missile camera)
+        // frame. Same shape as PushTgpFrame — see WantsRcFrames / RcFeed.cs.
+        public static void PushRcFrame(byte[] jpg)
+        {
+            if (jpg == null || jpg.Length == 0) return;
+            lock (_rcLock) { _rcJpg = jpg; _rcFrameId++; }
+        }
+
+        // Drops the cached RC frame so MJPEG clients see "no frame" again.
+        public static void ClearRcFrame()
+        {
+            lock (_rcLock) { _rcJpg = null; _rcFrameId++; }
+        }
+
+        // RC aim reticle — an absolute viewport position (0..1, 0..1), unlike the MAP cursor's
+        // velocity vector, because the reticle already has a well-defined "where it is right now"
+        // (the RC bridge's own smoothing/slew) that the browser just needs to mirror, not
+        // integrate itself. Ships on its own "rcaim" SSE event, change-gated like SetCursorVector.
+        internal static float RcAimX => Volatile.Read(ref _rcAimX);
+        internal static float RcAimY => Volatile.Read(ref _rcAimY);
+        internal static void SetRcAimVector(float x, float y)
+        {
+            x = (float)Math.Round(x, 3);
+            y = (float)Math.Round(y, 3);
+            if (_rcAimX == x && _rcAimY == y) return;   // steady hold — nothing to ship
+            Volatile.Write(ref _rcAimX, x);
+            Volatile.Write(ref _rcAimY, y);
+        }
+
         // Called from Unity main thread when a mission ends — clears all per-mission state so
         // the client drops back to "no mission" and wipes its display. Icons are static
         // per-type assets and stay cached across missions.
@@ -633,6 +675,8 @@ namespace NOXMFD
                         _ = Task.Run(() => HandleSseAsync(ctx, _cts.Token));
                     else if (path == "/tgp.mjpg")
                         _ = Task.Run(() => HandleMjpegAsync(ctx, _cts.Token));
+                    else if (path == "/rc.mjpg")
+                        _ = Task.Run(() => HandleRcMjpegAsync(ctx, _cts.Token));
                     else if (path == "/map" || path == "/map.png" || path == "/map.jpg")
                         ServeMap(ctx);
                     else if (path == "/icon")
@@ -677,6 +721,8 @@ namespace NOXMFD
                         ServeAssetRel(ctx, "pages/afm/afm.html");
                     else if (path == "/tgp")
                         ServeAssetRel(ctx, "pages/tgp/tgp.html");
+                    else if (path == "/rc")
+                        ServeAssetRel(ctx, "pages/rc/rc.html");
                     else if (path == "/wpn")
                         ServeAssetRel(ctx, "pages/wpn/wpn.html");
                     else if (path == "/rwr")
@@ -1334,6 +1380,51 @@ namespace NOXMFD
             }
         }
 
+        // Same shape as HandleMjpegAsync above, reading the RC buffers instead of the TGP ones.
+        // Kept as its own method (rather than parameterizing) because the two feeds' subscriber
+        // counters / gates (WantsTgpFrames vs WantsRcFrames) are separate statics, not fields on a
+        // shared object.
+        private static async Task HandleRcMjpegAsync(HttpListenerContext ctx, CancellationToken ct)
+        {
+            const string boundary = "rcframe";
+            ctx.Response.StatusCode  = 200;
+            ctx.Response.ContentType = "multipart/x-mixed-replace; boundary=" + boundary;
+            ctx.Response.SendChunked = true;
+            ctx.Response.Headers.Add("Cache-Control", "no-cache");
+            ctx.Response.Headers.Add("X-Accel-Buffering", "no");
+
+            long lastSeen = -1;
+            Interlocked.Increment(ref _rcSubscribers);
+            try
+            {
+                while (!ct.IsCancellationRequested)
+                {
+                    byte[]? jpg; long id;
+                    lock (_rcLock) { jpg = _rcJpg; id = _rcFrameId; }
+
+                    if (jpg != null && id != lastSeen)
+                    {
+                        lastSeen = id;
+                        string head = "\r\n--" + boundary + "\r\nContent-Type: image/jpeg\r\nContent-Length: " + jpg.Length + "\r\n\r\n";
+                        byte[] headBytes = Encoding.ASCII.GetBytes(head);
+                        await ctx.Response.OutputStream.WriteAsync(headBytes, 0, headBytes.Length, ct).ConfigureAwait(false);
+                        await ctx.Response.OutputStream.WriteAsync(jpg, 0, jpg.Length, ct).ConfigureAwait(false);
+                        ctx.Response.OutputStream.Flush();
+                    }
+
+                    // Source publishes at 20 Hz (~50 ms/frame); 30 ms polls stay ahead.
+                    await Task.Delay(30, ct).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception) { /* client disconnected, normal */ }
+            finally
+            {
+                Interlocked.Decrement(ref _rcSubscribers);
+                try { ctx.Response.Close(); } catch { }
+            }
+        }
+
         // ── SSE handler ────────────────────────────────────────────────────────
 
         private static async Task HandleSseAsync(HttpListenerContext ctx, CancellationToken ct)
@@ -1381,6 +1472,7 @@ namespace NOXMFD
                 // the expensive snapshot keeps its 10 Hz. lastCursor suppresses repeats, so a centred
                 // stick costs one comparison per tick and no traffic at all.
                 string lastCursor = string.Empty;
+                string lastRcAim  = string.Empty;
                 int sinceFrame = FrameEveryMs;   // send a frame immediately on connect
                 while (!ct.IsCancellationRequested)
                 {
@@ -1400,6 +1492,14 @@ namespace NOXMFD
                         lastCursor = cursor;
                         byte[] cbytes = Encoding.UTF8.GetBytes("event: cursor\ndata: " + cursor + "\n\n");
                         await ctx.Response.OutputStream.WriteAsync(cbytes, 0, cbytes.Length, ct).ConfigureAwait(false);
+                    }
+
+                    string rcAim = RcAimJson();
+                    if (!string.Equals(rcAim, lastRcAim, StringComparison.Ordinal))
+                    {
+                        lastRcAim = rcAim;
+                        byte[] rbytes = Encoding.UTF8.GetBytes("event: rcaim\ndata: " + rcAim + "\n\n");
+                        await ctx.Response.OutputStream.WriteAsync(rbytes, 0, rbytes.Length, ct).ConfigureAwait(false);
                     }
                     ctx.Response.OutputStream.Flush();
 
@@ -1471,6 +1571,7 @@ namespace NOXMFD
                         + ",\"rwr\":" + RwrArray(s.Rwr)
                         + ",\"mw\":" + MwArray(s.Mw)
                         + ",\"rdr\":" + RdrBlock(s)
+                        + ",\"rc\":" + RcBlock(s)
                         + ",\"radar\":" + (s.RadarOn ? "true" : "false")
                         + ",\"guns\":" + (s.GunsLinked ? "true" : "false")
                         + ",\"ign\":" + (s.Ignition ? "true" : "false")
@@ -1674,6 +1775,37 @@ namespace NOXMFD
                 "{{\"present\":true,\"range\":{0:0.0},\"cone\":{1:0.0},\"metric\":{2},\"lvlt\":{3:0.000},\"items\":{4},\"pb\":{5}}}",
                 s.RadarRange, s.RadarConeDeg, s.RdrMetric ? "true" : "false", s.RdrLevelTime, RdrArray(s.Rdr), pb);
         }
+
+        // MissileCamera: Remote Control status (soft dependency — RcBridge.cs / McBridge.cs).
+        // "available":false covers both "mod not installed" and "installed but too old" — the
+        // page shows the same not-installed state either way, no need for the client to tell them
+        // apart. The aim reticle itself is NOT here — see the "rcaim" SSE event / RcAimJson.
+        private static string RcBlock(TelemetrySnapshot s)
+        {
+            if (!s.RcAvailable) return "{\"available\":false}";
+            // "tele"/"markers" are spliced in verbatim (see TelemetrySnapshot.RcTeleJson/RcMarkersJson)
+            // rather than built via string.Format like the rest of this block — they're already valid,
+            // pre-escaped JSON straight from the base MissileCamera mod (McBridge.cs), and re-threading
+            // their fields through format args here would just be a second, easier-to-drift copy.
+            string tele = string.IsNullOrEmpty(s.RcTeleJson) ? "null" : s.RcTeleJson!;
+            string markers = string.IsNullOrEmpty(s.RcMarkersJson) ? "[]" : s.RcMarkersJson;
+            return string.Format(CultureInfo.InvariantCulture,
+                "{{\"available\":true,\"fsActive\":{0},\"controlling\":{1},\"missile\":\"{2}\"," +
+                "\"thr\":{3:0.000},\"boost\":{4},\"link\":\"{5}\",\"formation\":{6},\"pool\":{7},\"tele\":{8},\"markers\":{9}}}",
+                s.RcFsActive ? "true" : "false",
+                s.RcControlling ? "true" : "false",
+                EscapeJson(s.RcMissileName ?? string.Empty),
+                s.RcThrottle,
+                s.RcBoost ? "true" : "false",
+                EscapeJson(s.RcLink ?? string.Empty),
+                s.RcFormation ? "true" : "false",
+                StringArray(s.RcPool),
+                tele,
+                markers);
+        }
+
+        private static string RcAimJson() => string.Format(CultureInfo.InvariantCulture,
+            "{{\"x\":{0:0.000},\"y\":{1:0.000}}}", RcAimX, RcAimY);
 
         // Pitbull missiles (issue #40): the player's own AA missiles with an active-radar seeker
         // currently locked. tid is the designated target's persistentID.Id, 0 if none/unresolved —

--- a/src/plugin/TelemetrySnapshot.cs
+++ b/src/plugin/TelemetrySnapshot.cs
@@ -100,6 +100,22 @@ namespace NOXMFD
         // game's 3-second post-loss hold is still running). Drives the MFD's NO TARGET fallback.
         public bool   TgpActive;
 
+        // MissileCamera: Remote Control status (soft dependency — RcBridge.cs / McBridge.cs).
+        // RcAvailable=false covers both "RC add-on not installed" and "installed but too old" —
+        // see RcBridge.cs. RcTeleJson/RcMarkersJson are pre-escaped JSON spliced verbatim from the
+        // base MissileCamera mod (McBridge.cs), not parsed here.
+        public bool     RcAvailable;
+        public bool     RcFsActive;
+        public bool     RcControlling;
+        public string?  RcMissileName;
+        public float    RcThrottle;
+        public bool     RcBoost;
+        public string?  RcLink;
+        public bool     RcFormation;
+        public string[]? RcPool;
+        public string?  RcTeleJson;
+        public string?  RcMarkersJson;
+
         // Per-part HP for the AVN page. Built from Aircraft.partLookup, one entry per
         // damageable UnitPart. Names match the silhouette layout served at /airframe-layout.
         public PartHp[] Parts;

--- a/src/web/pages/rc/rc.css
+++ b/src/web/pages/rc/rc.css
@@ -1,0 +1,187 @@
+/* RC page — Missile Camera: Remote Control feed + controls. Base reset / colour tokens / font /
+   .mfd-empty / .pad-cursor come from theme.css. See rc.html for the message contract. */
+
+.rc-panel {
+  position: absolute;
+  inset: 0;
+  background: #000;
+  overflow: hidden;
+}
+
+/* Same centred-box reasoning as TGP: hide the whole interactive layer (surface + status +
+   controls) rather than just the image, so a dead/uninstalled RC never leaves stray buttons
+   floating over black. */
+.rc-panel:not(.has-rc) .rc-surface,
+.rc-panel:not(.has-rc) .rc-status,
+.rc-panel:not(.has-rc) .rc-throttle,
+.rc-panel:not(.has-rc) .rc-actions,
+.rc-panel:not(.has-rc) .rc-pool { display: none; }
+.rc-panel.has-rc .rc-empty { display: none; }
+
+.rc-surface {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%;
+  height: 100%;
+  touch-action: none;   /* the surface owns drag — no browser scroll/zoom gestures to fight */
+  cursor: crosshair;
+}
+.rc-img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background: #000;
+  pointer-events: none;   /* drags are handled by .rc-surface, not the <img> itself */
+}
+/* No feed yet (fullscreen not active / camera not live) — keep the black box, drop the stale
+   frame MJPEG would otherwise keep buffered in the element (same reasoning as TGP). */
+.rc-panel:not(.has-feed) .rc-img { visibility: hidden; }
+
+.rc-reticle {
+  /* .pad-cursor already gives position/size/crosshair sprite/will-change — this just turns it
+     on and lifts it above the feed image. */
+  display: block;
+}
+
+.rc-status {
+  position: absolute;
+  top: 8px; left: 0; right: 0;
+  display: flex;
+  justify-content: center;
+  gap: 18px;
+  font-family: var(--no-font);
+  font-size: 13px;
+  letter-spacing: 1.5px;
+  color: var(--no-green);
+  text-shadow: 0 1px 2px rgba(0,0,0,0.9);
+  pointer-events: none;
+}
+.rc-link.degraded { color: var(--no-amber); }
+.rc-link.lost      { color: var(--no-red); }
+.rc-formation { color: var(--no-green-dark); }
+.rc-formation.active { color: var(--no-green); }
+
+.rc-btn {
+  font-family: var(--no-font);
+  font-size: 12px;
+  letter-spacing: 1px;
+  color: var(--no-green);
+  background: var(--no-panel-bg);
+  border: 1px solid var(--no-panel-border);
+  padding: 6px 10px;
+  border-radius: 2px;
+}
+.rc-btn:active { background: rgba(57,255,20,0.18); }
+.rc-btn.on { color: var(--no-ink); background: var(--no-green); }
+
+.rc-throttle {
+  position: absolute;
+  right: 8px; top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+.rc-thr-gauge {
+  width: 14px;
+  height: 140px;
+  background: var(--no-panel-bg);
+  border: 1px solid var(--no-panel-border);
+  display: flex;
+  align-items: flex-end;
+}
+.rc-thr-fill {
+  width: 100%;
+  height: 0%;   /* set inline per-frame by rc.js */
+  background: var(--no-green);
+}
+.rc-boost { margin-top: 4px; }
+.rc-boost.on { color: var(--no-ink); background: var(--no-amber); border-color: var(--no-amber); }
+
+.rc-actions {
+  position: absolute;
+  left: 8px; bottom: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.rc-det { color: var(--no-red); border-color: var(--no-red); }
+.rc-det:active { background: rgba(255,64,64,0.22); }
+
+.rc-pool {
+  position: absolute;
+  left: 8px; top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 60%;
+  overflow-y: auto;
+}
+.rc-pool:empty { display: none; }
+.rc-pool-item {
+  font-family: var(--no-font);
+  font-size: 12px;
+  color: var(--no-green-dim);
+  background: var(--no-panel-bg);
+  border: 1px solid var(--no-panel-border);
+  padding: 4px 8px;
+  text-align: left;
+}
+.rc-pool-item:active { background: rgba(57,255,20,0.18); }
+
+.rc-tele {
+  position: absolute;
+  right: 8px; bottom: 8px;
+  display: flex;
+  gap: 14px;
+  font-family: var(--no-font);
+  font-size: 12px;
+  letter-spacing: 0.5px;
+  color: var(--no-green);
+  text-shadow: 0 1px 2px rgba(0,0,0,0.9);
+  pointer-events: none;
+}
+.rc-panel:not(.has-rc) .rc-tele,
+.rc-panel:not(.has-tele) .rc-tele { display: none; }
+.rc-tele-col { display: flex; flex-direction: column; gap: 2px; align-items: flex-end; }
+.rc-tele-lbl { color: var(--no-green-dim); margin-right: 6px; }
+.rc-tele-tti {
+  align-self: flex-end;
+  color: var(--no-amber);
+  font-weight: bold;
+}
+
+.rc-markers {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+.rc-marker {
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  transform: translate(-50%, -50%);
+  border: 1.5px solid currentColor;
+  box-sizing: border-box;
+}
+.rc-marker-label {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 2px;
+  font-family: var(--no-font);
+  font-size: 10px;
+  color: currentColor;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.9);
+  white-space: nowrap;
+}
+.rc-marker.selected {
+  width: 28px;
+  height: 28px;
+  border-width: 2px;
+  box-shadow: 0 0 4px currentColor;
+}

--- a/src/web/pages/rc/rc.html
+++ b/src/web/pages/rc/rc.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>NO XMFD — RC</title>
+<!--
+  Bare RC page served at /rc (docs/rc-page.md). Missile Camera: Remote Control's feed + controls,
+  mirroring the RC mod's own in-cockpit fullscreen view. Unlike TGP/RDR this page both receives
+  state AND sends commands — it owns a drag-to-aim pointer surface and a few buttons, POSTing
+  through send-command.js the same way TGT/MAP do.
+
+  Shell -> page messages (all {mfd:true, ...}):
+    'rc'    : { available, fsActive, controlling, missile, thr, boost, link, formation, pool, tele, markers }
+              Mirrors the "rc" telemetry block (TelemetryServer.RcBlock) at the normal frame rate.
+              tele mirrors the base MissileCamera mod's own Fullscreen HUD text fields 1:1 (same
+              pre-formatted strings/units — see McBridge.cs there): { missile, target, ownship,
+              speed, alt, range, g, fuel, mach, guidance, tgtAngle, hasTarget, hasTti, ttiSec,
+              ttiFrac, closMs, relAltM, infrared, salvoIdx, salvoTotal, visionMode } or null when
+              there's no trackable missile (visionMode is still set even then — see McBridge.cs).
+              markers is an array of cockpit HUD target markers reprojected onto the feed camera's
+              viewport: [{ n (name), x, y (0..1, Unity convention — y=0 bottom, flip for CSS top
+              like the aim reticle), sel (bool — locked/selected target), c (hex color) }, ...],
+              always an array (empty when nothing to show).
+    'rcaim' : { x, y } — reticle viewport position (0..1, 0..1), forwarded from its own high-rate
+              SSE event ("rcaim") the same way MAP's PAD cursor rides its own event. Positions the
+              reticle only; does NOT drive aiming (aiming is this page's own pointer drag, sent as
+              rc.aim command deltas — see rc.js).
+    'orient': app-wide orientation (kept for parity with every other page).
+
+  Page -> game commands (POST /command via sendCommand, src/plugin/CommandDispatcher.cs):
+    rc.aim{x,y}, rc.throttle-set{v}, rc.throttle-adjust{v}, rc.boost{on}, rc.take, rc.take-at{index},
+    rc.release, rc.formation, rc.detonate, rc.refresh-pool, rc.vision-cycle.
+
+  The MJPEG <img> connects to /rc.mjpg directly — the server only emits frames while this page (or
+  a pane running it) is open, via TelemetryServer.WantsRcFrames (RcFeed.cs).
+-->
+<link rel="stylesheet" href="/assets/shared/font.css">
+<link rel="stylesheet" href="/assets/shared/theme.css">
+<link rel="stylesheet" href="/assets/pages/rc/rc.css">
+</head>
+<body>
+  <div class="rc-panel" id="rc-panel">
+    <div class="rc-empty mfd-empty" id="rc-empty">
+      <span class="mfd-empty-title">RC</span><span id="rc-empty-msg">— NOT INSTALLED —</span>
+    </div>
+
+    <!-- Aim surface: covers the feed, captures pointer drags, hosts the feed image + reticle. -->
+    <div class="rc-surface" id="rc-surface">
+      <img class="rc-img" id="rc-img" alt="">
+      <div class="rc-markers" id="rc-markers"></div>
+      <div class="pad-cursor rc-reticle" id="rc-reticle"></div>
+    </div>
+
+    <!-- Status strip: missile name, link quality, formation flag. -->
+    <div class="rc-status" id="rc-status">
+      <span class="rc-missile" id="rc-missile"></span>
+      <span class="rc-link" id="rc-link"></span>
+      <span class="rc-formation" id="rc-formation">FORM</span>
+    </div>
+
+    <!-- Throttle: vertical bar readout + nudge buttons (no slider — matches the physical
+         tap-to-ramp keybind rather than pretending to be a precision analog control). -->
+    <div class="rc-throttle" id="rc-throttle">
+      <button class="rc-btn rc-thr-up"   id="rc-thr-up"   type="button">THR+</button>
+      <div class="rc-thr-gauge"><div class="rc-thr-fill" id="rc-thr-fill"></div></div>
+      <button class="rc-btn rc-thr-down" id="rc-thr-down" type="button">THR−</button>
+      <button class="rc-btn rc-boost" id="rc-boost" type="button">AB</button>
+    </div>
+
+    <!-- Session controls. -->
+    <div class="rc-actions" id="rc-actions">
+      <button class="rc-btn rc-take"    id="rc-take"    type="button">TAKE</button>
+      <button class="rc-btn rc-release" id="rc-release" type="button">RELEASE</button>
+      <button class="rc-btn rc-form-btn" id="rc-form-btn" type="button">FORM</button>
+      <button class="rc-btn rc-vision" id="rc-vision" type="button">VIS</button>
+      <button class="rc-btn rc-det" id="rc-det" type="button">DETONATE</button>
+    </div>
+
+    <!-- Missile picker: shown on demand (rc-pool-toggle), lists ControllablePool by index. -->
+    <div class="rc-pool" id="rc-pool"></div>
+
+    <!-- Telemetry readout — mirrors the base MissileCamera mod's own Fullscreen HUD text fields
+         1:1 (docs/rc-page.md "tele"); same pre-formatted strings, not reformatted here. -->
+    <div class="rc-tele" id="rc-tele">
+      <div class="rc-tele-col">
+        <div><span class="rc-tele-lbl">SPD</span><span id="rc-tele-spd"></span></div>
+        <div><span class="rc-tele-lbl">ALT</span><span id="rc-tele-alt"></span></div>
+        <div><span class="rc-tele-lbl">RNG</span><span id="rc-tele-rng"></span></div>
+        <div><span class="rc-tele-lbl">FUEL</span><span id="rc-tele-fuel"></span></div>
+      </div>
+      <div class="rc-tele-col">
+        <div><span class="rc-tele-lbl">MACH</span><span id="rc-tele-mach"></span></div>
+        <div><span class="rc-tele-lbl">G</span><span id="rc-tele-g"></span></div>
+        <div><span class="rc-tele-lbl">GUID</span><span id="rc-tele-guid"></span></div>
+        <div><span class="rc-tele-lbl">TGT&ang;</span><span id="rc-tele-tgtangle"></span></div>
+      </div>
+      <div class="rc-tele-tti" id="rc-tele-tti"></div>
+    </div>
+  </div>
+
+<script src="/assets/services/send-command.js"></script>
+<script src="/assets/pages/rc/rc.js"></script>
+</body>
+</html>

--- a/src/web/pages/rc/rc.js
+++ b/src/web/pages/rc/rc.js
@@ -1,0 +1,266 @@
+// RC page — Missile Camera: Remote Control feed + controls. See rc.html for the full message
+// contract (shell -> page: 'rc' status block + high-rate 'rcaim' reticle; page -> game: rc.*
+// commands via sendCommand, src/plugin/CommandDispatcher.cs / RcBridge.cs).
+//
+// Unlike TGP (pure reactive renderer) this page also OWNS input: a drag-to-aim pointer surface
+// over the feed, plus a few buttons. Aim deltas are batched on a short timer rather than sent per
+// pointermove — same reasoning as the physical mouse (PollMouse accumulates a frame's motion,
+// not each OS mouse-move event), and it keeps this to a handful of POSTs/sec instead of hundreds.
+
+const rcPanel   = document.getElementById('rc-panel');
+const rcEmptyMsg= document.getElementById('rc-empty-msg');
+const rcSurface = document.getElementById('rc-surface');
+const rcImg     = document.getElementById('rc-img');
+const rcReticle = document.getElementById('rc-reticle');
+const rcMissile = document.getElementById('rc-missile');
+const rcLink    = document.getElementById('rc-link');
+const rcFormation = document.getElementById('rc-formation');
+const rcThrFill = document.getElementById('rc-thr-fill');
+const rcBoostBtn= document.getElementById('rc-boost');
+const rcTakeBtn = document.getElementById('rc-take');
+const rcReleaseBtn = document.getElementById('rc-release');
+const rcFormBtn = document.getElementById('rc-form-btn');
+const rcVisionBtn = document.getElementById('rc-vision');
+const rcDetBtn  = document.getElementById('rc-det');
+const rcThrUp   = document.getElementById('rc-thr-up');
+const rcThrDown = document.getElementById('rc-thr-down');
+const rcPoolEl  = document.getElementById('rc-pool');
+const rcTeleSpd = document.getElementById('rc-tele-spd');
+const rcTeleAlt = document.getElementById('rc-tele-alt');
+const rcTeleRng = document.getElementById('rc-tele-rng');
+const rcTeleFuel = document.getElementById('rc-tele-fuel');
+const rcTeleMach = document.getElementById('rc-tele-mach');
+const rcTeleG   = document.getElementById('rc-tele-g');
+const rcTeleGuid = document.getElementById('rc-tele-guid');
+const rcTeleTgtAngle = document.getElementById('rc-tele-tgtangle');
+const rcTeleTti = document.getElementById('rc-tele-tti');
+const rcMarkersEl = document.getElementById('rc-markers');
+
+// Last known 'rc' status block, so button handlers (which fire outside the message handler)
+// can read current state without their own bookkeeping.
+let state = { available: false, fsActive: false, controlling: false, formation: false, pool: [] };
+
+rcImg.src = '/rc.mjpg';
+rcImg.addEventListener('error', function() { rcPanel.classList.remove('has-feed'); });
+
+// ── Aim drag ────────────────────────────────────────────────────────────────────────
+// Degrees per CSS pixel of drag — tuned to feel roughly like the in-cockpit mouse sensitivity
+// at default game settings; the RC bind is itself a slew rate, not a fixed mapping, so this is
+// a starting point rather than a precise conversion. Adjust here if it feels too twitchy/slow.
+const AIM_DEG_PER_PX = 0.15;
+const AIM_SEND_MS = 40;   // ~25 Hz — smooth without flooding /command
+
+let dragging = false;
+let lastX = 0, lastY = 0;
+let pendingYaw = 0, pendingPitch = 0;
+
+rcSurface.addEventListener('pointerdown', function(e) {
+  if (!state.controlling) return;
+  dragging = true;
+  lastX = e.clientX;
+  lastY = e.clientY;
+  rcSurface.setPointerCapture(e.pointerId);
+});
+
+rcSurface.addEventListener('pointermove', function(e) {
+  if (!dragging) return;
+  const dx = e.clientX - lastX;
+  const dy = e.clientY - lastY;
+  lastX = e.clientX;
+  lastY = e.clientY;
+  pendingYaw   += dx * AIM_DEG_PER_PX;
+  pendingPitch += dy * AIM_DEG_PER_PX;   // screen-down == pitch-up-negative, matches RcBridge's convention
+});
+
+function endDrag(e) {
+  if (!dragging) return;
+  dragging = false;
+  try { rcSurface.releasePointerCapture(e.pointerId); } catch (err) {}
+}
+rcSurface.addEventListener('pointerup', endDrag);
+rcSurface.addEventListener('pointercancel', endDrag);
+rcSurface.addEventListener('pointerleave', endDrag);
+
+setInterval(function() {
+  if (pendingYaw === 0 && pendingPitch === 0) return;
+  sendCommand('rc.aim', { x: pendingYaw, y: pendingPitch }).catch(function() {});
+  pendingYaw = 0;
+  pendingPitch = 0;
+}, AIM_SEND_MS);
+
+// ── Buttons ─────────────────────────────────────────────────────────────────────────
+rcTakeBtn.addEventListener('click', function() {
+  sendCommand('rc.take', {}).catch(function() {});
+});
+rcReleaseBtn.addEventListener('click', function() {
+  sendCommand('rc.release', {}).catch(function() {});
+});
+rcFormBtn.addEventListener('click', function() {
+  sendCommand('rc.formation', {}).catch(function() {});
+});
+rcVisionBtn.addEventListener('click', function() {
+  sendCommand('rc.vision-cycle', {}).catch(function() {});
+});
+rcThrUp.addEventListener('click', function() {
+  sendCommand('rc.throttle-adjust', { v: 0.1 }).catch(function() {});
+});
+rcThrDown.addEventListener('click', function() {
+  sendCommand('rc.throttle-adjust', { v: -0.1 }).catch(function() {});
+});
+
+// Afterburner is a hold, not a tap — mirrors the physical keybind's level-triggered behavior
+// (ThrottleController.SetExternalBoost). Pointer events cover mouse + touch uniformly.
+rcBoostBtn.addEventListener('pointerdown', function() {
+  sendCommand('rc.boost', { on: true }).catch(function() {});
+});
+function releaseBoost() {
+  sendCommand('rc.boost', { on: false }).catch(function() {});
+}
+rcBoostBtn.addEventListener('pointerup', releaseBoost);
+rcBoostBtn.addEventListener('pointercancel', releaseBoost);
+rcBoostBtn.addEventListener('pointerleave', releaseBoost);
+
+// Manual detonate is irreversible — require a deliberate ~600 ms press-and-hold rather than a
+// single tap, the same way a cockpit guard flap makes a critical action hard to fat-finger.
+const DETONATE_HOLD_MS = 600;
+let detonateTimer = null;
+rcDetBtn.addEventListener('pointerdown', function() {
+  rcDetBtn.classList.add('on');
+  detonateTimer = setTimeout(function() {
+    detonateTimer = null;
+    sendCommand('rc.detonate', {}).catch(function() {});
+  }, DETONATE_HOLD_MS);
+});
+function cancelDetonate() {
+  rcDetBtn.classList.remove('on');
+  if (detonateTimer) { clearTimeout(detonateTimer); detonateTimer = null; }
+}
+rcDetBtn.addEventListener('pointerup', cancelDetonate);
+rcDetBtn.addEventListener('pointercancel', cancelDetonate);
+rcDetBtn.addEventListener('pointerleave', cancelDetonate);
+
+// ── Missile picker ──────────────────────────────────────────────────────────────────
+// Only worth showing while nothing is under control — once controlling, TAKE targets "next
+// best" and the picker would just be a second, redundant way to do the same thing.
+function renderPool(pool) {
+  rcPoolEl.innerHTML = '';
+  if (state.controlling || !pool || pool.length === 0) return;
+  pool.forEach(function(name, i) {
+    const item = document.createElement('div');
+    item.className = 'rc-pool-item';
+    item.textContent = name || ('#' + i);
+    item.addEventListener('click', function() {
+      sendCommand('rc.take-at', { index: i }).catch(function() {});
+    });
+    rcPoolEl.appendChild(item);
+  });
+}
+
+// ── Telemetry readout ───────────────────────────────────────────────────────────────
+// Mirrors the base MissileCamera mod's own Fullscreen HUD text 1:1 — these are already
+// formatted (units, rounding) server-side, so this just places them, no reformatting.
+function renderTele(tele) {
+  const has = !!tele;
+  rcPanel.classList.toggle('has-tele', has);
+
+  // visionMode rides even in the "no trackable missile" partial object (see McBridge.cs
+  // TelemetryJson) — it's a global selection, not missile-specific — so update the button
+  // regardless of `has`, and bail only for the fields that genuinely need a missile.
+  rcVisionBtn.textContent = (has && tele.visionMode) ? tele.visionMode.replace(/^MODE:\s*/, 'VIS ') : 'VIS';
+  if (!has) return;
+
+  rcTeleSpd.textContent = tele.speed || '';
+  rcTeleAlt.textContent = tele.alt || '';
+  rcTeleRng.textContent = tele.range || '';
+  rcTeleFuel.textContent = tele.fuel || '';
+  rcTeleMach.textContent = tele.mach || '';
+  rcTeleG.textContent = tele.g || '';
+  rcTeleGuid.textContent = tele.guidance || '';
+  rcTeleTgtAngle.textContent = tele.hasTarget ? (tele.tgtAngle || '') : '';
+
+  if (tele.hasTti) {
+    rcTeleTti.textContent = 'TTI ' + tele.ttiSec.toFixed(1) + 's';
+  } else {
+    rcTeleTti.textContent = '';
+  }
+}
+
+// ── Target markers ──────────────────────────────────────────────────────────────────
+// Cockpit HUD markers reprojected onto the feed camera (docs/rc-page.md "rc.markers") — same
+// viewport-flip reasoning as the aim reticle (server uses Unity's y=0-bottom convention).
+// Full clear+rebuild each update: marker counts are small (a handful of contacts), and this
+// rides the normal telemetry rate, not the high-rate rcaim channel — no need to diff.
+function renderMarkers(markers) {
+  rcMarkersEl.innerHTML = '';
+  if (!markers || markers.length === 0) return;
+
+  markers.forEach(function(m) {
+    const el = document.createElement('div');
+    el.className = 'rc-marker' + (m.sel ? ' selected' : '');
+    el.style.left = (m.x * 100) + '%';
+    el.style.top = ((1 - m.y) * 100) + '%';
+    el.style.color = m.c || '#ffffff';
+
+    if (m.n) {
+      const label = document.createElement('div');
+      label.className = 'rc-marker-label';
+      label.textContent = m.n;
+      el.appendChild(label);
+    }
+
+    rcMarkersEl.appendChild(el);
+  });
+}
+
+// ── Status rendering ────────────────────────────────────────────────────────────────
+function applyRcState(m) {
+  state = m;
+
+  rcPanel.classList.toggle('has-rc', !!m.available);
+  rcPanel.classList.toggle('has-feed', !!m.fsActive);
+
+  if (!m.available) {
+    rcEmptyMsg.textContent = '— NOT INSTALLED —';
+  } else if (!m.fsActive) {
+    rcEmptyMsg.textContent = '— CAMERA NOT ACTIVE —';
+  }
+
+  rcMissile.textContent = m.controlling ? (m.missile || '') : '';
+
+  rcLink.textContent = m.controlling ? (m.link || '') : '';
+  rcLink.classList.toggle('degraded', m.link === 'Degraded');
+  rcLink.classList.toggle('lost', m.link === 'Lost');
+
+  rcFormation.classList.toggle('active', !!m.formation);
+
+  rcThrFill.style.height = Math.round((m.thr || 0) * 100) + '%';
+  rcBoostBtn.classList.toggle('on', !!m.boost);
+
+  rcTakeBtn.disabled = !m.fsActive || m.controlling;
+  rcReleaseBtn.disabled = !m.controlling;
+  rcFormBtn.disabled = !m.controlling;
+  rcDetBtn.disabled = !m.controlling;
+
+  renderPool(m.pool);
+  renderTele(m.tele);
+  renderMarkers(m.markers);
+}
+
+// ── Shell messages ──────────────────────────────────────────────────────────────────
+window.addEventListener('message', function(e) {
+  const m = e.data;
+  if (!m || m.mfd !== true) return;
+
+  if (m.type === 'rc') {
+    applyRcState(m);
+  } else if (m.type === 'rcaim') {
+    // RcBridge.ReticleViewport uses Unity's viewport convention (0 = bottom, 1 = top — same as
+    // Camera.WorldToViewportPoint), but CSS `top` counts from the top of the box. Flip Y here;
+    // X needs no flip (both conventions agree left→right).
+    rcReticle.style.left = (m.x * 100) + '%';
+    rcReticle.style.top  = ((1 - m.y) * 100) + '%';
+  } else if (m.type === 'orient') {
+    document.body.classList.toggle('portrait',  m.orientation === 'portrait');
+    document.body.classList.toggle('landscape', m.orientation !== 'portrait');
+  }
+});

--- a/src/web/services/telemetry-source.js
+++ b/src/web/services/telemetry-source.js
@@ -104,6 +104,15 @@ export class TelemetrySource {
     es.addEventListener('cursor', (e) => {
       try { this._onCursor(JSON.parse(e.data)); } catch (err) { /* malformed — skip this one */ }
     });
+    // RC (MissileCamera: Remote Control) aim reticle — same reasoning as the MAP cursor above: a
+    // continuous analog value that would feel laggy riding the 10 Hz telemetry frame. Unlike the
+    // cursor it isn't SOI/pane-scoped, so this is a plain pass-through, no stateful dedup needed.
+    es.addEventListener('rcaim', (e) => {
+      try {
+        const c = JSON.parse(e.data);
+        this._postUp({ type: 'rcaim', x: c.x, y: c.y });
+      } catch (err) { /* malformed — skip this one */ }
+    });
     es.onmessage = (e) => this._onMessage(e);
     es.onerror = () => {};   // EventSource auto-reconnects; the watchdog decides when to flag DISCONNECTED
     // Watchdog — tolerate transient SSE blips, only flag disconnect after a real gap.
@@ -371,6 +380,11 @@ export class TelemetrySource {
       pb: pbItems
     });
 
+    // RC (MissileCamera: Remote Control) status — pass the mod's "rc" block straight through
+    // (available:false when the RC add-on isn't installed/too old). The aim reticle itself rides
+    // its own high-rate "rcaim" SSE event (see connect()), not this slice.
+    this._postUp(Object.assign({ type: 'rc' }, d.rc || { available: false }));
+
     // Aircraft name + per-part HP (the AVN damage silhouette; assets fetched on demand by the page).
     this._postUp({
       type: 'avn',
@@ -457,6 +471,7 @@ export class TelemetrySource {
     this._postUp({ type: 'loadout', items: [], selWeapon: null, softGun: null, softRel: null, masterArmsOn: true, combatMode: 'all' });
     this._postUp({ type: 'cm', flares: -1, flaresMax: -1, ewKJ: -1, ewKJMax: -1, cmCat: 0 });
     this._postUp({ type: 'tgp', active: false });
+    this._postUp({ type: 'rc', available: false });
     this._postUp({ type: 'mapinfo', mission: null, grid: null, x: null, z: null, hdg: null, ox: null, oy: null });
     this._postUp({ type: 'targets', items: [] });
     this._postUp({ type: 'rwr', items: [] });

--- a/src/web/shell/classic/mfd.js
+++ b/src/web/shell/classic/mfd.js
@@ -739,6 +739,35 @@ function forwardTgpToFrame() {
   const w = frameWin(); if (!w) return;
   w.postMessage({ mfd: true, type: 'tgp', active: tgpActive }, '*');
 }
+// RC (MissileCamera: Remote Control) status block — same shape as TGP's forward pair, but the
+// whole status object (not just a lock flag) since rc.js renders missile/link/throttle/pool/
+// telemetry from it directly.
+function forwardRcToPanes() {
+  paneIframes.forEach(function(iframe, idx) {
+    if (panePages[idx] !== 'rc') return;
+    if (!iframe.contentWindow) return;
+    iframe.contentWindow.postMessage(Object.assign({ mfd: true, type: 'rc' }, rcData), '*');
+  });
+}
+function forwardRcToFrame() {
+  const w = frameWin(); if (!w) return;
+  w.postMessage(Object.assign({ mfd: true, type: 'rc' }, rcData), '*');
+}
+// RC aim reticle — its own high-rate channel (SSE event "rcaim"), same reasoning as the MAP
+// cursor: a continuous analog value that would feel laggy riding the 10 Hz telemetry frame.
+// Page-gated like the rest of RC (not SOI-focus routed like the PAD cursor) — it's a passive
+// readout, not an input surface.
+function forwardRcAimToPanes() {
+  paneIframes.forEach(function(iframe, idx) {
+    if (panePages[idx] !== 'rc') return;
+    if (!iframe.contentWindow) return;
+    iframe.contentWindow.postMessage({ mfd: true, type: 'rcaim', x: rcAimData.x, y: rcAimData.y }, '*');
+  });
+}
+function forwardRcAimToFrame() {
+  const w = frameWin(); if (!w) return;
+  w.postMessage({ mfd: true, type: 'rcaim', x: rcAimData.x, y: rcAimData.y }, '*');
+}
 function forwardRwrToPanes() {
   paneIframes.forEach(function(iframe, idx) {
     if (panePages[idx] !== 'rwr') return;
@@ -1208,6 +1237,7 @@ paneIframes.forEach(function(iframe, idx) {
     else if (page === 'avn')  { forwardAvnToPanes(); forwardAvnLayoutToPanes(); }
     else if (page === 'afm')  forwardAfmToPanes();
     else if (page === 'tgp')  forwardTgpToPanes();
+    else if (page === 'rc')   { forwardRcToPanes(); forwardRcAimToPanes(); }
     else if (page === 'rwr')  { forwardRwrToPanes(); forwardMwToPanes(); }
     else if (page === 'rdr')  forwardRdrToPanes();
     else if (page === 'tgt')  { forwardTgtToPanes(); forwardTgtTargetsToPanes(); }
@@ -1235,6 +1265,7 @@ pageFrame.addEventListener('load', function() {
   forwardOrientationToPane(pageFrame);
   if (currentPage === 'wpn')      { forwardWpnLayoutToFrame(); forwardWpnToFrame(); forwardCmToFrame(); }
   else if (currentPage === 'tgp') { forwardTgpToFrame(); }
+  else if (currentPage === 'rc')  { forwardRcToFrame(); forwardRcAimToFrame(); }
   else if (currentPage === 'avn') { forwardAvnLayoutToFrame(); forwardAvnToFrame(); }
   else if (currentPage === 'afm') { forwardAfmLayoutToFrame(); forwardAfmToFrame(); }
   else if (currentPage === 'rwr') { forwardRwrToFrame(); forwardMwToFrame(); }
@@ -1379,6 +1410,12 @@ let cmData = { flares: -1, flaresMax: -1, ewKJ: -1, ewKJMax: -1, cmCat: 0 };
 // Latest TGP feed state mirrored from the map iframe. False until the first frame is
 // produced, and back to false during the 3-second post-loss hold's expiry.
 let tgpActive = false;
+
+// Latest RC (MissileCamera: Remote Control) status block mirrored from the map iframe.
+// available=false until the RC add-on resolves (docs comment on RcBridge.cs).
+let rcData = { available: false, fsActive: false, controlling: false, formation: false, pool: [] };
+// Latest RC aim reticle position — its own high-rate channel, see forwardRcAimToPanes/Frame.
+let rcAimData = { x: 0.5, y: 0.5 };
 
 // Latest selected-target list mirrored from the map iframe. The TGT page renders it under its
 // filters (forwardTgtTargetsToFrame) — the whole list, unpaginated, since that page scrolls.
@@ -1547,6 +1584,13 @@ function showPage(name) {
   if (name === 'tgp') {
     showFramePage('tgp');
     forwardTgpToFrame();
+  }
+  // RC renders in #page-frame too. Same shape as TGP — static MAIN label, no extra nav wiring —
+  // but forwards the whole status block plus the aim reticle's high-rate channel.
+  if (name === 'rc') {
+    showFramePage('rc');
+    forwardRcToFrame();
+    forwardRcAimToFrame();
   }
   // AVN renders in #page-frame too. Its MAIN label (NAV.avn) is placed by the generic sweep
   // above; the 8 avn.toggle groups get their own keys + NAV labels here (placeAvnNavLabels), then
@@ -1732,6 +1776,15 @@ window.addEventListener('message', function(e) {
     // Only matters while the TGP page is in view — outside it the frame/pane isn't shown.
     if (currentPage === 'tgp' && !splitMode) forwardTgpToFrame();
     if (splitMode) forwardTgpToPanes();
+  } else if (m.type === 'rc') {
+    rcData = m;
+    // Only matters while the RC page is in view — outside it the frame/pane isn't shown.
+    if (currentPage === 'rc' && !splitMode) forwardRcToFrame();
+    if (splitMode) forwardRcToPanes();
+  } else if (m.type === 'rcaim') {
+    rcAimData = { x: typeof m.x === 'number' ? m.x : 0.5, y: typeof m.y === 'number' ? m.y : 0.5 };
+    if (currentPage === 'rc' && !splitMode) forwardRcAimToFrame();
+    if (splitMode) forwardRcAimToPanes();
   } else if (m.type === 'avn') {
     avnData = {
       name: m.name || null,
@@ -2211,6 +2264,7 @@ function mfdButton(el) {
     case 'combat-mode-aa':  sendCommand('combat-mode.set', { group: 'aa'  }).catch(function() {}); break;
     case 'combat-mode-ag':  sendCommand('combat-mode.set', { group: 'ag'  }).catch(function() {}); break;
     case 'tgp':  showPage('tgp');  break;
+    case 'rc':   showPage('rc');   break;
     case 'hud':  showPage('hud');  break;
     case 'keys':  showPage('keys');  break;
     case 'rates': showPage('rates'); break;   // cfg-rates experiment (issue #39) — CFG group's RTS

--- a/src/web/shell/classic/split-slots.js
+++ b/src/web/shell/classic/split-slots.js
@@ -39,6 +39,7 @@
     avn: [ { side: 'left', slot: 0 } ],
     afm: [ { side: 'left', slot: 0 } ],
     tgp: [ { side: 'left', slot: 0 } ],
+    rc:  [ { side: 'left', slot: 0 } ],
     rwr: [ { side: 'left', slot: 0 } ],
     // RDR gets MAIN plus the range rocker (R+/R-, issue #40 follow-up) all on the left column, right
     // after MAIN — unlike MAP's zoom rocker, which splits onto the right column (MAP has more items

--- a/src/web/shell/f35/f35.js
+++ b/src/web/shell/f35/f35.js
@@ -73,6 +73,7 @@
     rwr: ['rwr', 'mw'],       // scope contacts + incoming-missile warnings
     tgt: ['tgt', 'targets'],
     tgp: ['tgp'],
+    rc:  ['rc', 'rcaim'],
     wpn: ['loadout', 'cm'],   // 'loadout' is derived, not forwarded as-is — see DERIVED
     bdf: ['bdf'],             // read-only faction-forces block (docs/bdf-page.md)
     pal: ['pal'],             // same, for PRIMEVA

--- a/src/web/shell/layout-pages.js
+++ b/src/web/shell/layout-pages.js
@@ -21,6 +21,7 @@
   const CLASSIC_FULL = {
     wpn:  '/wpn',
     tgp:  '/tgp',
+    rc:   '/rc',
     avn:  '/avn',
     afm:  '/afm',
     rwr:  '/rwr',
@@ -46,6 +47,7 @@
     avn:  '/avn?bare',
     afm:  '/afm?bare',
     tgp:  '/tgp?bare',
+    rc:   '/rc?bare',
     wpn:  '/wpn?bare',
     rwr:  '/rwr?bare',
     rdr:  '/rdr?bare',
@@ -77,6 +79,7 @@
     rdr:  '/rdr',
     tgt:  '/tgt',
     tgp:  '/tgp',
+    rc:   '/rc',
     wpn:  '/wpn',
     akf:  '/akf',
     bdf:  '/bdf',

--- a/src/web/shell/nav-model.js
+++ b/src/web/shell/nav-model.js
@@ -35,10 +35,12 @@
       { label: 'MAP', action: 'map' },     // → MAP page
       { label: 'RWR', action: 'rwr' },     // → RWR page
       { label: 'TGP', action: 'tgp' },     // → TGP page
+      { label: 'RC',  action: 'rc'  },     // → RC page (MissileCamera: Remote Control feed)
       { label: 'TGT', action: 'tgt' },     // → TGT page (target-selection filter)
       { label: 'WPN', action: 'wpn' },     // → WPN page
     ],
     tgp: [ { label: 'MAIN', action: 'main' } ],   // ← back to MAIN
+    rc:  [ { label: 'MAIN', action: 'main' } ],   // ← back to MAIN
     avn: [ { label: 'MAIN', action: 'main' } ],
     afm: [ { label: 'MAIN', action: 'main' } ],   // Airframe page — name + damage silhouette
     rwr: [ { label: 'MAIN', action: 'main' } ],

--- a/src/web/shell/nav-model.test.js
+++ b/src/web/shell/nav-model.test.js
@@ -34,12 +34,12 @@ for (const [page, items] of Object.entries(NAV)) {
 // ── Ordering is the contract ────────────────────────────────────────────────────────
 // A layout renderer places by INDEX (bezel full view: item i → left key i; bezel split:
 // SPLIT_SLOTS[i] places NAV[i]). So order is meaningful and reordering is a behaviour change.
-assert.deepStrictEqual(NAV.main.map(i => i.label), ['AVN', 'MAP', 'RWR', 'TGP', 'TGT', 'WPN']);
+assert.deepStrictEqual(NAV.main.map(i => i.label), ['AVN', 'MAP', 'RWR', 'TGP', 'RC', 'TGT', 'WPN']);
 assert.deepStrictEqual(NAV.map.map(i => i.label), ['MAIN', 'GRID', 'FLW', 'WPT', 'R+', 'R-', 'W+', 'W-', 'Z+', 'Z-']);
 assert.deepStrictEqual(NAV.rdr.map(i => i.label), ['MAIN', 'R+', 'R-']);
 
 // ── Every frame-hosted page can get back to MAIN ────────────────────────────────────
-for (const page of ['avn', 'afm', 'rwr', 'tgp', 'tgt', 'hud']) {
+for (const page of ['avn', 'afm', 'rwr', 'tgp', 'rc', 'tgt', 'hud']) {
   assert.deepStrictEqual(NAV[page], [{ label: 'MAIN', action: 'main' }], `${page} should be just a MAIN back-button`);
 }
 


### PR DESCRIPTION
## Summary
Applies lupfine's fork work (https://github.com/lupfine/NOXMFD) for an RC missile-camera MFD page, rebuilt clean on top of current `main` rather than merged from his branch — his branch's base commit silently reverts 0.21.0→0.19.3 (see `_scratch/lupfine-review/NOISE.md`), so a normal merge would have dragged in a lot of unrelated regressions (dropped routes, dropped telemetry fields, a weaker `EscapeJson`).

- New soft-dependency bridges `McBridge.cs` (base MissileCamera mod) and `RcBridge.cs` (MissileCamera: Remote Control add-on), plus `RcFeed.cs` — same continuous-capture shape as `TgpFeed.cs`.
- New `/rc` page (`src/web/pages/rc/*`) with drag-to-aim, throttle/boost/formation/detonate controls, and a missile picker.
- `CommandDispatcher.cs`: 11 new `rc.*` commands, all safe no-ops when the RC mods aren't installed.
- `TelemetryServer.cs`: `/rc.mjpg` feed, `/rc` route, `rcaim` high-rate SSE event, `RcBlock` in the telemetry JSON.
- Wired into both shells' navigation (classic bezel + F-35 glass) and the telemetry relay, split-pane included.

## Known gaps (left as-is, not silently fixed)
- `RcFsActive` uses `_rc.Active` rather than lupfine's original wiring, which wasn't cleanly recoverable from his noisy diff — flagged with a `ponytail:` comment in `TelemetryReader.cs`.
- The MJPEG cold-start stall lupfine hit and backed out of fixing (his last 3 commits: added, removed, added, removed a placeholder-frame fix) is still present in `HandleRcMjpegAsync`.
- Untestable in-game here — soft-depends on two mods (`MissileCamera`, `MissileCameraRemoteControl`) neither installed in this environment.

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] Full web test suite (`find src/web -name '*.test.js' -exec node {} \;`) — all green
- [ ] In-game verification with both MissileCamera mods installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)